### PR TITLE
fix(twitch-auth): fix version to prevent error when connect to chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "sirv": "^1.0.6",
     "socket.io": "^2.3.0",
     "soundex": "^0.2.1",
-    "twitch": "^4.2.6",
-    "twitch-auth": "^4.2.6",
-    "twitch-chat-client": "^4.2.6",
+    "twitch": "^4.3.6",
+    "twitch-auth": "^4.3.6",
+    "twitch-chat-client": "^4.3.6",
     "uuid": "^8.3.1",
     "youtube-player": "^5.5.2"
   },


### PR DESCRIPTION
There is irc error in 4.2.6. Fix that's error with update package.